### PR TITLE
Fix: Use original options for friend's quiz

### DIFF
--- a/quiz.js
+++ b/quiz.js
@@ -777,15 +777,13 @@ document.addEventListener('DOMContentLoaded', () => {
           currentQuestionIndex = 0;
           userAnswers = [];
 
-          quizQuestions = quizData.answers.map(q => ({
-            question: q.question,
-            options: [
-              { text: q.answer },
-              { text: "Random A" },
-              { text: "Random B" },
-              { text: "Random C" }
-            ].sort(() => Math.random() - 0.5)
-          }));
+          quizQuestions = quizData.answers.map(q => {
+            const originalQuestion = allQuestions.find(aq => aq.question === q.question);
+            return {
+              question: q.question,
+              options: [...originalQuestion.options].sort(() => Math.random() - 0.5)
+            };
+          });
 
           window.correctAnswers = quizData.answers.map(q => q.answer);
           window.friendName = friendName;


### PR DESCRIPTION
When a friend was taking a quiz, the options displayed were 'Random A', 'Random B', and 'Random C' instead of the original options for the question.

This was happening because the code was hardcoding these random options when generating the quiz for a friend.

This commit fixes the issue by finding the original question in the `allQuestions` array and using its options. The options are also shuffled to ensure they appear in a random order for the friend.